### PR TITLE
Add error handling for devices without WebGL

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,8 @@
   <div id="loading-overlay">
   <div id="loading-spinner">Loading data...</div>
   <div id="loading-error" style="display: none;">
-    Failed to load data.<br>
+    Failed to load map.<br>
+    <small id='loading-error-message'></small><br>
     <button id="retry-button">Retry</button>
   </div>
 </div>

--- a/js/main.js
+++ b/js/main.js
@@ -240,9 +240,10 @@ function hideLoadingOverlay() {
   if (overlay) overlay.style.display = 'none';
 }
 
-function showLoadingError() {
+function showLoadingError(error) {
   document.getElementById('loading-spinner').style.display = 'none';
   document.getElementById('loading-error').style.display = 'block';
+  document.getElementById('loading-error-message').textContent = error.message;
 }
 
 function setupRetryHandler() {
@@ -443,14 +444,11 @@ function isDefaultViewInUrl() {
   }
 });
 
-await mapManager.initialize();
-    
-
-
 setupRetryHandler();
-initData()
+await mapManager.initialize()
+  .then(() => initData())
   .then(hideLoadingOverlay)
   .catch(error => {
     console.error('Initialization failed:', error);
-    showLoadingError();
+    showLoadingError(error);
   });

--- a/js/map.js
+++ b/js/map.js
@@ -346,15 +346,24 @@ document.addEventListener('click', (e) => {
   iconNames = ['blue', 'brightblue', 'yellow', 'orange', 'red'];
 
   async initialize() {
-    this.map = new maplibregl.Map({
-      container: this.containerId,
-      style: this.styleUrl,
-      center: this.center,
-      zoom: this.zoom,
-      pitch: 0,
-      bearing: 0,
-      dragRotate: false
-    });
+    try {
+      this.map = new maplibregl.Map({
+        container: this.containerId,
+        style: this.styleUrl,
+        center: this.center,
+        zoom: this.zoom,
+        pitch: 0,
+        bearing: 0,
+        dragRotate: false
+      });
+    } catch (e) {
+      const errorBody = JSON.parse(e.message);
+      if (errorBody.type === 'webglcontextcreationerror') {
+        throw new Error('This browser or device doesn\'t support WebGL');
+      } else {
+        throw new Error('An unknown issue occured while creating the map');
+      }
+    }
 
     this.map.dragRotate.disable();
     this.map.touchZoomRotate.disableRotation();


### PR DESCRIPTION
If merged, this PR will:
- Add error handling to `js/map.js` in `mapManager.initialize()` that will throw a helpful error if the user is using a device or browser that doesn't support WebGL, or if maplibregl can't load the WebGL context for any other reason
- Add `mapManager.initialize()` to the promise chain for loading the data, so that if it fails, the `loading-error` dialog box shows up
- Add a message to the `loading-error` box indicating what went wrong, which uses `error.message` from the thrown error.

<img width="1280" height="652" alt="Screenshot of IndoorCO2Map.com on a browser with no WebGL support. The website displays an error message that reads: Failed to load map. This browser or device does not support WebGL" src="https://github.com/user-attachments/assets/02f64da3-32a9-4a14-b828-6ac344051f71" />

I was confused why the map wouldn't load on my browser, and I figured out that it has to do with WebGL support, which maplibregl has a kind of opaque way of indicating.

One way to deal with this case (which is implemented in this PR) is to add the `mapManager.initialize()` step to that final promise callback chain used to run `initData` in `js/main.js`, and then display the error message in the `loading-error` box. One issue is that this is kind of an abuse of the `setupRetryHandler` function which is obviously designed to help the user recover from errors, while an issue with WebGL support probably isn't recoverable at least without reloading the page.

I tried my best to mirror your coding style in this implementation but if you have any suggestions, or think it'd be better to implement this in another way, I wouldn't mind revisiting it

I did notice #1 in the process (and verified that it isn't a regression from this PR) though I figured it'd be better to treat that bug separately